### PR TITLE
Initialize Go module and project structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,44 @@
+# Binaries for programs and plugins
+*.exe
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool
+*.out
+
+# Dependency directories (if vendor directory is used)
+vendor/
+
+# Go workspace file
+*.work
+
+# Logs
+*.log
+
+# Temporary files
+*.tmp
+*.swp
+*.swo
+*~
+
+# OS generated files
+.DS_Store
+Thumbs.db
+
+# Docker files
+.docker/
+docker-compose.override.yml
+docker-compose.local.yml
+
+Desktop.ini
+$RECYCLE.BIN/
+
+# Environment files
+.env
+
+# Docker logs
+*.container.log

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -1,0 +1,3 @@
+package main
+
+func main() {}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module go-postgresql
+
+go 1.23.8


### PR DESCRIPTION
## Summary
- initialize Go module
- set up a standard `.gitignore`
- add a minimal `cmd/app` main program

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_6852d285e600832ab88ed22fd216e228