### PR TITLE
Add basic command for go-postgresql

### DIFF
--- a/cmd/go-postgresql/main.go
+++ b/cmd/go-postgresql/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "log"
+
+func main() {
+    log.Println("go-postgresql starting up")
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module go-postgresql
+
+go 1.23.8


### PR DESCRIPTION
## Summary
- introduce a new `cmd/go-postgresql` application
- minimal `main()` logs start up
- initialize module for build support

## Testing
- `go build ./cmd/go-postgresql`


------
https://chatgpt.com/codex/tasks/task_b_6852d29a86cc832a95f1824316624a70